### PR TITLE
Electron build and signing automation

### DIFF
--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -37,13 +37,13 @@ jobs:
         # Import Apple API key for app notarization on macOS
         run: |
           mkdir -p ~/private_keys/
-          echo '${{ secrets.api_key }}' > ~/private_keys/AuthKey_${{ secrets.api_key_id }}.p8
+          echo '${{ secrets.API_KEY }}' > ~/private_keys/AuthKey_${{ secrets.API_KEY_ID }}.p8
 
       - name: Build Electron app
         uses: samuelmeuli/action-electron-builder@v1
         env:
-          API_KEY_ID: ${{ secrets.APPLE_ID }}
-          API_KEY_ISSUER_ID: ${{ secrets.APPLE_ID_PASSWORD }}
+          API_KEY_ID: ${{ secrets.API_KEY_ID }}
+          API_KEY_ISSUER_ID: ${{ secrets.API_KEY_ISSUER_ID }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
This could be functional but without having an Apple Developer account I cannot validate it. This is what you should need to grab from the Apple Developer portal and add to the repo secrets.

- Obtain Apple Developer Certificates:
  - Enroll in the Apple Developer Program.
  - Generate a Developer ID Application certificate and a Developer ID Installer certificate from your Apple Developer account. These are crucial for distributing apps outside the Mac App Store.
- Export and Secure Certificates:
  - Open Keychain Access on your macOS machine.
  - Locate and export both your Developer ID certificates as a single .p12 file.
  - Set a strong password for this .p12 file during export.
  - Base64-encode the .p12 file using the command: `base64 -i your_certificates.p12 -o encoded_certs.txt`
- Configure GitHub Secrets:
  - In your GitHub repository, navigate to Settings > Secrets > Actions.
  - Add a new secret named MAC_CERTS and paste the entire content of your encoded_certs.txt file into its value.
  - Add another secret named MAC_CERTS_PASSWORD and set its value to the password you created for the .p12 file.
  - Add APPLE_ID and APPLE_ID_PASSWORD (an app-specific password generated in your Apple ID settings).

When completed, the list of secrets added to the repo should be:

API_KEY
API_KEY_ID
API_KEY_ISSUER_ID
MAC_CERTS
MAC_CERTS_PASSWORD