### PR TITLE
sign binaries for usb access in Sequoia

### DIFF
--- a/firmware/installer/package.json
+++ b/firmware/installer/package.json
@@ -45,6 +45,10 @@
       "entitlements": "build/entitlements.mac.plist",
       "entitlementsInherit": "build/entitlements.mac.plist",
       "notarize": true,
+      "binaries": [
+        "resources/binaries/omap_loader-macos-x64",
+        "resources/binaries/omap_loader-macos-arm64"
+      ],
       "target": [
         {
           "target": "zip",


### PR DESCRIPTION
Fix a permissions issue with the usb-handler for macos that are not based on Silicon Mac. This particular issue is showing up on Mac mini running Sequioa 15.4.1 (24E263)

On Sequoia, unsigned binaries are blocked even when executed via sudo-prompt. The binary in app.asar.unpacked/resources/binaries/ needs to be signed with the same certificate as the Electron app.