### PR TITLE
fall back to node:24-alpine for compatibility

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:25-alpine AS builder
+FROM node:24-alpine AS builder
 
 WORKDIR /app
 COPY . .
 RUN npm install
 RUN npm run build
 
-FROM node:25-alpine AS runtime
+FROM node:24-alpine AS runtime
 
 WORKDIR /app
 RUN mkdir dist


### PR DESCRIPTION
workaround docker hub network tls issues when adding packages specific for aarch64 build (x86_64 unaffected)