### PR TITLE
Add workflow to build for Dockerhub

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -43,7 +43,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha,prefix={{branch}}-
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5


### PR DESCRIPTION
I added in a workflow that'll build a Dockerhub image on push for the **server.**  This will then make the server available in the pre-buillt Docker containers for the likes of Unraid etc.

You'll need to add the secret variables to your github repo secrets for this to push. 