### PR TITLE
Fix post-install "fetch failed" on default installs (monit + busybox2 bootstrap)

### DIFF
--- a/firmware/builder/build.sh
+++ b/firmware/builder/build.sh
@@ -522,13 +522,14 @@ set +e
 mkdir -p /tmp/1 || true
 mount /dev/mtdblock7 /tmp/1 -tjffs2 || true
 
+cp /bin/busybox2 /tmp/1/bin/busybox2 || true
+chmod 777 /tmp/1/bin/busybox2
+
 ROOTME_EOF
 
       if [ "$ENABLE_ROOT_ACCESS" = true ]; then
         cat >> "$ROOTME_SCRIPT" << 'ROOTME_EOF'
-cp /bin/busybox2 /tmp/1/bin/busybox2 || true
 cp /bin/autossh /tmp/1/bin/autossh || true
-chmod 777 /tmp/1/bin/busybox2
 chmod 777 /tmp/1/bin/autossh
 
 cp /bin/dropbearmulti /tmp/1/bin/dropbearmulti

--- a/firmware/builder/build.sh
+++ b/firmware/builder/build.sh
@@ -602,7 +602,12 @@ ln -sf /bin/busybox2 /tmp/1/bin/httpd || true
 if ! grep -q "nleapi start" /tmp/1/etc/init.d/rcS; then
   echo '${INITDIR}/nleapi start' >> /tmp/1/etc/init.d/rcS
 fi
-if ! grep -q "httpd.monitrc" /tmp/1/etc/monitrc; then
+# mtdblock7 persists across re-flash, so older builds that did this
+# unconditionally may have left a duplicate `include httpd.monitrc` line
+# in /etc/monitrc. Strip any existing one first so re-flashing onto a
+# previously-broken device recovers cleanly.
+sed -i '\|^include /etc/monit\.d/httpd\.monitrc$|d' /tmp/1/etc/monitrc
+if ! grep -qE "include /etc/monit\.d/(\*|httpd)\.monitrc" /tmp/1/etc/monitrc; then
   echo "include /etc/monit.d/httpd.monitrc" >> /tmp/1/etc/monitrc
 fi
 ROOTME_EOF

--- a/firmware/builder/deps/httpd.monitrc
+++ b/firmware/builder/deps/httpd.monitrc
@@ -5,7 +5,7 @@
 #
 # Daemon cycles are 5 seconds each so to check every minute,
 # its 12 cycles. So 3 minutes is 12*3 = 36
-check process httpd matching /usr/sbin/httpd
+check process httpd matching /bin/httpd
   start program = "/etc/init.d/nleapi monit_start" with timeout 20 seconds
   stop program = "/etc/init.d/nleapi monit_stop"
   if 5 restarts within 100 cycles then unmonitor


### PR DESCRIPTION
## Problem

A default `v1.0.1` install (without `--enable-root-access`) can't finish the installer's URL-config step — it fails with `fetch failed`. Three separate bugs in the `rootme` bootstrap that `firmware/builder/build.sh` generates add up to break it.

**1. `httpd.monitrc` gets included twice.** `build.sh` appends `include /etc/monit.d/httpd.monitrc` to `/etc/monitrc`, guarded by `grep -q "httpd.monitrc"`. But the stock Nest `/etc/monitrc` already has `include /etc/monit.d/*.monitrc`, and the literal-string guard doesn't match the glob — so it gets included twice and monit won't start (duplicate service name). I widened the guard to a regex that matches either form, and added a `sed` to strip a pre-existing explicit include first, so re-flashing a device that's already broken (mtdblock7 survives a re-flash) recovers on its own.

**2. `httpd.monitrc` watches the wrong path.** It has `matching /usr/sbin/httpd`, but `nleapi monit_start` launches `${BINDIR}/httpd` = `/bin/httpd` (`BINDIR` is `/bin`, from the stock `/etc/init.d/functions`). So monit never sees the httpd it started, and keeps restarting it until it hits `if 5 restarts within 100 cycles then unmonitor` and gives up. Changed it to `matching /bin/httpd`.

**3. `busybox2` only gets copied with `--enable-root-access`.** The `cp /bin/busybox2 /tmp/1/bin/busybox2` was inside the root-access block, but the `ln -sf /bin/busybox2 /tmp/1/bin/httpd` symlink right after it is unconditional — so a default install ends up with a dangling symlink. The cgi-bin scripts (`update`, `api/settings`) also call `busybox2 sed`/`wget`/`unzip` directly, so the URL-config CGI fails with `busybox2: not found`. Moved the `cp` + `chmod` out of the conditional.

## How I found it

I dumped both rootfs banks off a live Gen 2 — `mtdblock7` (the active, post-NLE one) and `mtdblock9` (the inactive A/B slot, still on the factory 4.3.3 image) — and diffed them with `jefferson`:

- mtd9 (the stock baseline) has only the glob include in `/etc/monitrc`, `BINDIR=/bin` in `/etc/init.d/functions`, and no `busybox2` anywhere.
- mtd7 showed bugs 1 and 2: `/etc/monitrc` had both the glob *and* the explicit `include /etc/monit.d/httpd.monitrc`, and `httpd.monitrc` still had `matching /usr/sbin/httpd`.
- Bug 3 I confirmed by reading the rootme that `build.sh` writes with `ENABLE_ROOT_ACCESS=false` — the only `busybox2` line left is the symlink, with no `cp`, and the baseline has no `busybox2` to begin with.

## Tested

Flashed this branch onto a Gen 2 and checked the running device:

- monit is running, and `/etc/monitrc` has only the glob include — no duplicate (fix 1).
- `httpd.monitrc` has `matching /bin/httpd`, and httpd is running, so monit is actually tracking it (fix 2).
- `/bin/busybox2` is there and `/bin/httpd -> /bin/busybox2` resolves (fix 3).

The device boots and works end-to-end. This was an `--enable-root-access` build — since fix 3 moves the busybox2 `cp` so it runs either way, it landing correctly here covers that part. The one thing I haven't run directly is a default (no-root) build through the installer's URL-config step, which is the exact case the bugs hit; happy to do that before merge, or someone with a spare Gen 2 can.
